### PR TITLE
Use NAN for compatibility with Node 0.11+

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -3,6 +3,7 @@
     {
       'target_name': 'synth',
       'include_dirs': [
+        '<!(node -e "require(\'nan\')\")',
         'src'
       ],
       'sources': [

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "dependencies": {
     "bindings": "~1.0.0",
+    "nan": "~2.2.1",
     "through": "~1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Allows `node-gyp` build to complete on newer Node versions.

``` bash
OS X 10.11.4

$ npm -v
3.6.0

$ node -v
v5.7.1
```
